### PR TITLE
Handle client crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pmap = fun(F, L) -> Pid = self(), [receive {P, Result} -> Result end ||
                                          X <- L]] end.
 
 D = fun(T) -> timer:sleep(T) end.
-DR = fun(T) -> timer:sleep(random:uniform(T)) end.
+DR = fun(T) -> timer:sleep(rand:uniform(T)) end.
 
 T = fun(F) -> {T, R} = timer:tc(F), {T/(1000*1000), R} end.
 

--- a/src/fuse.erl
+++ b/src/fuse.erl
@@ -22,7 +22,7 @@
 -module(fuse).
 -behaviour(gen_server).
 
--export([start_link/3, call/2, is_burnt/1, stop/1]).
+-export([start_link/3, call/2, is_burnt/1, stop/1, burn/1]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
@@ -72,6 +72,9 @@ is_burnt(Fuse) ->
 
 -spec stop(pid() | atom()) -> ok.
 stop(Fuse) -> gen_server:call(Fuse, stop).
+
+-spec burn(pid() | atom()) -> ok.
+burn(Fuse) -> gen_server:cast(Fuse, burn).
 
 %%%_* Gen server callbacks =============================================
 init([{Init, Timeouts, Probe}, Owner, LogFun]) ->

--- a/src/fuse_pool.erl
+++ b/src/fuse_pool.erl
@@ -85,7 +85,7 @@ handle_call(reserve_fuse, _From, #state{available=[F | T]} = S) ->
   {reply, {ok, F}, S#state{available=T, worker_shortage=false}};
 handle_call(reserve_fuse, From, #state{available=[], queue=Q} = S) ->
   log_worker_shortage(S),
-  NewQ = queue:in({From, now()}, Q),
+  NewQ = queue:in({From, erlang:timestamp()}, Q),
   {noreply, S#state{queue=NewQ, worker_shortage=true}};
 handle_call(get_num_active, _From, #state{all=All} = S) ->
   L = lists:filter(fun(X) -> not fuse:is_burnt(X) end, All),
@@ -109,7 +109,7 @@ handle_cast(Msg, S) -> {stop, {unexpected_cast, Msg}, S}.
 
 handle_info(prune, #state{queue=Q0, tmo=QueueTmo} = S) ->
   Prune = fun({From, Ts}) ->
-              case timer:now_diff(now(), Ts)  > (QueueTmo * 1000) of
+              case timer:now_diff(erlang:timestamp(), Ts)  > (QueueTmo * 1000) of
                 true  ->
                   gen_server:reply(From, {error, fuse_pool_queue_tmo}),
                   false;

--- a/src/fuse_pool.erl
+++ b/src/fuse_pool.erl
@@ -28,8 +28,15 @@
 %% is jobs waiting for an available fuse. 'tmo' is the max amount of
 %% milliseconds a job should be allowed in the queue. 'log' is the log
 %% fun. 'worker_shortage' is set to true if queuing has been started.
--record(state, {all=[], available=[], queue=queue:new(), tmo=undefined,
-                log=undefined, worker_shortage=false}).
+-record(state, { all=[]
+               , available=[]
+               , clients=[]
+               , queue=queue:new()
+               , tmo=undefined
+               , log=undefined
+               , worker_shortage=false}).
+
+-record(mapping, {fuse, client}).
 
 %%%_* API ==============================================================
 -spec start_link([fuse:fuse_data()], integer()) ->
@@ -81,8 +88,11 @@ init(FusesConfig, QueueTmo, LogFun) ->
   erlang:send_after(?PRUNE_PERIOD, self(), prune),
   {ok, #state{all=A, available=[], tmo=QueueTmo, log=LogFun}}.
 
-handle_call(reserve_fuse, _From, #state{available=[F | T]} = S) ->
-  {reply, {ok, F}, S#state{available=T, worker_shortage=false}};
+handle_call(reserve_fuse, {Pid, _Ref}, #state{available=[F | T], clients=Clients} = S) ->
+  Mapping = #mapping{fuse=F, client=erlang:monitor(process, Pid)},
+  {reply, {ok, F}, S#state{ available=T
+                          , worker_shortage=false
+                          , clients=[Mapping | Clients]}};
 handle_call(reserve_fuse, From, #state{available=[], queue=Q} = S) ->
   log_worker_shortage(S),
   NewQ = queue:in({From, erlang:timestamp()}, Q),
@@ -120,6 +130,17 @@ handle_info(prune, #state{queue=Q0, tmo=QueueTmo} = S) ->
   Q = queue:filter(Prune, Q0),
   erlang:send_after(?PRUNE_PERIOD, self(), prune),
   {noreply, S#state{queue=Q}};
+handle_info({'DOWN', Ref, process, Pid, _Reason}, #state{clients=Clients, log=L} = S) ->
+  case lists:keytake(Ref, #mapping.client, Clients) of
+    {value, Mapping, NewClients} ->
+      F = Mapping#mapping.fuse,
+      L("client (~p) exited without returning fuse (~p).", [Pid, F]),
+      fuse:burn(F),
+      {noreply, S#state{clients=NewClients}};
+    false ->
+      %% We might receive the DOWN before removing the monitor so ignore unknown ones
+      {noreply, S}
+  end;
 handle_info(Msg, S) ->
   {stop, {unexpected_info, Msg}, S}.
 
@@ -128,14 +149,24 @@ terminate(_Reason, _State) -> ok.
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %%%_* Internal =========================================================
-add_back_fuse(Fuse, #state{available=A, queue=Q0} = S) ->
+add_back_fuse(Fuse, #state{available=A, queue=Q0, clients=Clients} = S) ->
+  NewClients = case lists:keytake(Fuse, #mapping.fuse, Clients) of
+    {value, OldMapping, RemovedClients} ->
+      erlang:demonitor(OldMapping#mapping.client),
+      RemovedClients;
+    false ->
+      Clients
+  end,
   case queue:is_empty(Q0) of
     true  ->
-      S#state{available=lists:usort([Fuse | A])};
+      S#state{ available=lists:usort([Fuse | A])
+             , clients=NewClients};
     false ->
-      {{value, {From, _Ts}}, Q} = queue:out(Q0),
+      {{value, {{Pid, _} = From, _Ts}}, Q} = queue:out(Q0),
+      Mapping = #mapping{fuse=Fuse, client=erlang:monitor(process, Pid)},
       gen_server:reply(From, {ok, Fuse}),
-      S#state{available=A, queue=Q}
+      S#state{ available=A, queue=Q
+             , clients=[Mapping | NewClients]}
   end.
 
 log_worker_shortage(#state{worker_shortage=false, log=L}) ->

--- a/test/fuse_lb_tests.erl
+++ b/test/fuse_lb_tests.erl
@@ -8,14 +8,14 @@
 give_time_to_initialize_fuses() -> timer:sleep(7).
 
 probe_available(FuseNum) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, FuseNum}.
 
 probe_unavailable({init, FuseNum}) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, FuseNum};
 probe_unavailable(FuseNum) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {unavailable, FuseNum}.
 
 round_robin_test() ->
@@ -77,7 +77,7 @@ round_robin_failure_test() ->
 round_robin_probe_test() ->
   Cnt = fuse_misc:make_counter(),
   Probe = fun({init, FuseNum}) ->
-              timer:sleep(random:uniform(4)),
+              timer:sleep(rand:uniform(4)),
               {available, FuseNum};
              (X) ->
               case Cnt(inc) >= 3 of
@@ -121,7 +121,7 @@ round_robin_probe_test() ->
 round_robin_backoff_test() ->
   Cnt = fuse_misc:make_counter(),
   Probe = fun({init, FuseNum}) ->
-              timer:sleep(random:uniform(4)),
+              timer:sleep(rand:uniform(4)),
               {available, FuseNum};
              (X) ->
               case Cnt(inc) >= 5 of
@@ -233,10 +233,10 @@ race_helper(N) ->
   give_time_to_initialize_fuses(),
 
   fuse_misc:pmap(fun(_) ->
-                     timer:sleep(random:uniform(10)),
+                     timer:sleep(rand:uniform(10)),
                      fuse_lb:call(Lb,
                                   fun(State) ->
-                                      timer:sleep(random:uniform(5)),
+                                      timer:sleep(rand:uniform(5)),
                                       {unavailable, State}
                                   end)
                  end, lists:seq(1, 20)),

--- a/test/fuse_pool_tests.erl
+++ b/test/fuse_pool_tests.erl
@@ -8,14 +8,14 @@
 give_time_to_initialize_fuses() -> timer:sleep(7).
 
 probe_available(FuseNum) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, FuseNum}.
 
 probe_unavailable({init, FuseNum}) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, FuseNum};
 probe_unavailable(FuseNum) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {unavailable, FuseNum}.
 
 simple_calls_test() ->

--- a/test/fuse_tests.erl
+++ b/test/fuse_tests.erl
@@ -6,7 +6,7 @@
 %%%_* Tests ============================================================
 
 probe_available(state_data) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, state_data}.
 
 give_time_to_initialize_fuses() -> timer:sleep(7).

--- a/test/pooled_lb_tests.erl
+++ b/test/pooled_lb_tests.erl
@@ -8,7 +8,7 @@
 give_time_to_initialize_fuses() -> timer:sleep(10).
 
 probe_available(FuseNum) ->
-  timer:sleep(random:uniform(4)),
+  timer:sleep(rand:uniform(4)),
   {available, FuseNum}.
 
 %% Four workers in pool (w1, w2, w3, w4). Load balancer over two boxes


### PR DESCRIPTION
If a client crashes while waiting in the queue we'd end up assigning a fuse to a process that doesn't exist. We can monitor it to catch this, it would also catch if it somehow crashed and didn't return the fuse at any other point.

@define-null